### PR TITLE
Add OCI image support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bot-env/*
 /data/*
 /voice_files/*
+token

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12
+
+RUN mkdir /voicely-text
+
+WORKDIR /voicely-text
+
+COPY ["voicely-text.py", "README.md", "./legal", "requirements.txt", "LICENSE", "./"]
+
+RUN pip install -r requirements.txt
+
+CMD ["python", "voicely-text.py"]

--- a/voicely-text.py
+++ b/voicely-text.py
@@ -55,9 +55,20 @@ class Bot(commands.Bot):
 
 bot = Bot()
 
-# Read the bot token from external file
-with open('../token', 'r') as file:
-    TOKEN = file.read().strip()
+# Check token
+def get_token() -> str:
+    try:
+        with open('./token', 'r') as file:
+            token = file.read().strip()
+            if not token:
+                raise ValueError("The token file is empty. Make sure to put the token inside the token file.")
+                sys.exit(1)
+            return token
+    except FileNotFoundError as e:
+        raise FileNotFoundError("The token file wasn't found.") from e
+        sys.exit(1)
+    except Exception as e:
+        raise RuntimeError(f"An unexpected error occurred: {e}") from e
 
 # region save and load settings
 # region members settings
@@ -1638,7 +1649,7 @@ def run_bot():
     # signal.signal(signal.SIGTERM, run_shutdown)
 
     try:
-        loop.run_until_complete(bot.start(TOKEN))
+        loop.run_until_complete(bot.start(get_token()))
     except KeyboardInterrupt:
         print("Bot is shutting down...")
         loop.run_until_complete(shutdown())


### PR DESCRIPTION
# Goal
Add support to maintain and build OCI images easily to streamline updates and running of the bot.

# Changes
The following changes have been made:
- Replaced the `TOKEN` variable with a new function called `get_token()`. This will fetch the token and output errors and quit the program to easily tell the container manager that the bots token isn't available. It also quits with 1 indicating an error.
- Changed the token file to be in the same directory as the project to make configuration of the container a bit more straight forward.
- Added the token file to `.gitignore` to make sure it's not being accidentally pushed.
- Added a `Dockerfile` to build OCI images off of.